### PR TITLE
Add clang to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
   bison \
   build-essential \
   ca-certificates \
+  clang \
   cmake \
   curl \
   flex \


### PR DESCRIPTION
With the idea to add a build with clang warnings and another one (or the same) with its ubsan (once I finish pushing tickets and fixes).