### PR TITLE
Install docbook-xml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && \
   clang \
   cmake \
   curl \
+  docbook-xml \
   eatmydata \
   flex \
   gdb \


### PR DESCRIPTION
Needed for xmllint (used to check the docs) when it's unable to download remote files.