### PR TITLE
Add docbook-xsl-ns for garden test support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
   cmake \
   curl \
   docbook-xml \
+  docbook-xsl-ns \
   docbook5-xml \
   eatmydata \
   flex \


### PR DESCRIPTION
## Summary

The PostGIS garden tests (`make garden`) require `xsltproc` + docbook XSL stylesheets to generate garden test SQL from documentation XML. The Dockerfile has `xsltproc` and `docbook-xml` but is missing `docbook-xsl-ns`, causing PostGIS `configure` to skip doc support.

Without this package, `make garden` fails with:
```
configure was unable to find 'xsltproc' which is required to build the documentation.
```
and later:
```
/bin/sh: 1: cannot open ../doc/postgis_gardentest_37.sql: No such file
```

## Fix

Add `docbook-xsl-ns` to the `apt-get install` in the Dockerfile. This provides the XSL stylesheets at `/usr/share/xml/docbook/stylesheet/docbook-xsl-ns/` that PostGIS configure searches for.

## Testing

Verified that PostGIS `configure` detects the docbook xsl base directory after adding this package.