### PR TITLE
Define DOCKER_CMAKE_BUILD_TYPE before nlohmann/json build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,8 @@ ARG BUILD_THREADS=4
 
 
 # nlohmann/json - header-only library for SFCGAL (with CMake support)
+# Build type defaults to Release; override with --build-arg if needed.
+ARG DOCKER_CMAKE_BUILD_TYPE=Release
 RUN set -ex \
     && mkdir -p /usr/src \
     && cd /usr/src \


### PR DESCRIPTION
## Summary

The nlohmann/json install block added in c0c4440 (PR that closed #32) references `\${DOCKER_CMAKE_BUILD_TYPE}` in its cmake invocation:

```dockerfile
cmake .. -DCMAKE_BUILD_TYPE=\${DOCKER_CMAKE_BUILD_TYPE} -DJSON_BuildTests=OFF
```

…but no `ARG` or `ENV` with that name is declared anywhere in the Dockerfile, and `build.py` does not pass it as a `--build-arg`. At build time the variable expands to the empty string, so cmake effectively sees `-DCMAKE_BUILD_TYPE=` and falls back to its implicit default (no build type at all for this header-only project, which happens to be harmless but almost certainly is not what the author intended).

## Fix

Declare `ARG DOCKER_CMAKE_BUILD_TYPE=Release` immediately before the nlohmann/json `RUN`:

```dockerfile
# nlohmann/json - header-only library for SFCGAL (with CMake support)
# Build type defaults to Release; override with --build-arg if needed.
ARG DOCKER_CMAKE_BUILD_TYPE=Release
RUN set -ex \
    && ...
```

`Release` matches the build type used elsewhere in the Dockerfile (CGAL, GDAL, and GEOS all use `-DCMAKE_BUILD_TYPE=Release` explicitly). The `ARG` form preserves the original author's apparent intent of allowing an override via `--build-arg`.

## Testing

- Confirmed the variable is currently undefined anywhere in the Dockerfile or `build.py`:
  ```
  grep -rn DOCKER_CMAKE_BUILD_TYPE .
  Dockerfile:69:    && cmake .. -DCMAKE_BUILD_TYPE=\${DOCKER_CMAKE_BUILD_TYPE} -DJSON_BuildTests=OFF \
  ```
  (single reference, no declaration)
- After this PR, `docker build` shows cmake is invoked with `-DCMAKE_BUILD_TYPE=Release` as intended.

## Note for a future simplification (out of scope)

Debian trixie ships `nlohmann-json3-dev` version 3.11.3, which satisfies SFCGAL master's `find_package(nlohmann_json 3.11 REQUIRED)` declaration in its `CMakeLists.txt`, and installs a CMake package config file under `/usr/lib/*/cmake/nlohmann_json/`. A future PR could replace this ~20-line source-build block with a single entry in the `apt-get install` list, which would also eliminate the build-time network dependency on `api.github.com` (subject to unauthenticated 60 req/hour/IP rate limits) and `codeload.github.com`. That swap is intentionally **not** made here to keep this fix minimal and focused on the undefined-variable bug. Happy to open a follow-up if maintainers would prefer the apt approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)