### PR TITLE
Add CI for build environment images

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,0 +1,62 @@
+name: Container Images
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+
+jobs:
+  matrix:
+    name: Build matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: matrix
+        run: |
+          matrix="$(python3 build.py --no-push --print-matrix)"
+          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+
+  build:
+    name: ${{ matrix.image.tag }}
+    needs: matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        image: ${{ fromJson(needs.matrix.outputs.matrix).include }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to OSGeo registry
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: docker/login-action@v3
+        with:
+          registry: repo.osgeo.org
+          username: ${{ secrets.OSGEO_REGISTRY_USERNAME }}
+          password: ${{ secrets.OSGEO_REGISTRY_PASSWORD }}
+
+      - name: Build image
+        run: |
+          set -eu
+          publish=(--no-push)
+          repositories=(--repository postgis/postgis-build-env)
+          if test "${GITHUB_EVENT_NAME}" = "push" && test "${GITHUB_REF}" = "refs/heads/master"; then
+            publish=(--push)
+            repositories+=(--repository repo.osgeo.org/postgis/build-env)
+          fi
+          python3 build.py "${publish[@]}" "${repositories[@]}" --tag "${{ matrix.image.tag }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && \
   libgmp-dev \
   libicu-dev \
   libjson-c-dev \
+  liblz4-dev \
   libmpfr-dev \
   libpcre2-dev \
   libprotobuf-c-dev \
@@ -34,6 +35,7 @@ RUN apt-get update && \
   libtool \
   libxml2-dev \
   libxml2-utils \
+  libzstd-dev \
   llvm \
   pkg-config \
   protobuf-c-compiler \
@@ -89,8 +91,14 @@ RUN set -e; \
     chmod +x /usr/local/bin/build-threads; \
     echo "BUILD_THREADS resolved to: $(build-threads)"
 ARG SFCGAL_BUILD_THREADS=1
+ARG BUILD_DATE
 ARG DEBUG_CFLAGS="-O2 -g3 -ggdb -fno-omit-frame-pointer -DNDEBUG"
 ARG DEBUG_CXXFLAGS="-O2 -g3 -ggdb -fno-omit-frame-pointer -DNDEBUG"
+ARG GDAL_CMAKE_DRIVER_OPTIONS="-DGDAL_BUILD_OPTIONAL_DRIVERS=OFF -DOGR_BUILD_OPTIONAL_DRIVERS=OFF -DGDAL_ENABLE_DRIVER_GTIFF=ON -DGDAL_ENABLE_DRIVER_PNG=ON -DGDAL_ENABLE_DRIVER_JPEG=ON -DGDAL_ENABLE_DRIVER_MEM=ON -DGDAL_ENABLE_DRIVER_VRT=ON -DGDAL_ENABLE_DRIVER_HFA=ON -DOGR_ENABLE_DRIVER_GEOJSON=ON -DOGR_ENABLE_DRIVER_GPKG=ON -DOGR_ENABLE_DRIVER_SQLITE=ON -DOGR_ENABLE_DRIVER_ESRI_SHAPE=ON"
+ARG POSTGRES_EXTRA_CONFIGURE=""
+
+RUN mkdir -p /usr/local/share/postgis-build-env && \
+    printf 'BUILD_DATE=%s\n' "${BUILD_DATE}" > /usr/local/share/postgis-build-env/build-commits.env
 
 
 # nlohmann/json - header-only library for SFCGAL (with CMake support)
@@ -112,10 +120,12 @@ RUN set -ex \
     && make install \
     && cd /usr/src \
     && rm -rf "json-${NLOHMANN_JSON_VERSION}" nlohmann-json.tar.gz \
-    && echo "nlohmann/json ${NLOHMANN_JSON_VERSION} installed with CMake support" > /_pgis_nlohmann_json_version.txt
+    && echo "nlohmann/json ${NLOHMANN_JSON_VERSION} installed with CMake support" > /_pgis_nlohmann_json_version.txt \
+    && printf 'NLOHMANN_JSON_VERSION=%s\n' "${NLOHMANN_JSON_VERSION}" >> /usr/local/share/postgis-build-env/build-commits.env
 
 ARG CGAL_BRANCH=6.0.2
 RUN wget https://github.com/CGAL/cgal/releases/download/v${CGAL_BRANCH}/CGAL-${CGAL_BRANCH}.tar.xz && \
+    printf 'CGAL_BRANCH=%s\n' "${CGAL_BRANCH}" >> /usr/local/share/postgis-build-env/build-commits.env && \
     tar xJf CGAL-${CGAL_BRANCH}.tar.xz && \
     cd CGAL-${CGAL_BRANCH} && mkdir build && cd build && \
     cmake -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INSTALL_PREFIX=/src/CGAL .. && \
@@ -124,6 +134,7 @@ RUN wget https://github.com/CGAL/cgal/releases/download/v${CGAL_BRANCH}/CGAL-${C
 
 ARG SFCGAL_BRANCH=master
 RUN git clone --depth 1 --branch ${SFCGAL_BRANCH} https://gitlab.com/sfcgal/SFCGAL.git && \
+     printf 'SFCGAL_BRANCH=%s\nSFCGAL_COMMIT=%s\n' "${SFCGAL_BRANCH}" "$(git -C SFCGAL rev-parse HEAD)" >> /usr/local/share/postgis-build-env/build-commits.env && \
      cd SFCGAL && \
      mkdir cmake-build && \
      cd cmake-build && \
@@ -140,6 +151,7 @@ RUN git clone --depth 1 --branch ${SFCGAL_BRANCH} https://gitlab.com/sfcgal/SFCG
 
 ARG PROJ_BRANCH=master
 RUN git clone --depth 1 --branch ${PROJ_BRANCH} https://github.com/OSGeo/PROJ && \
+    printf 'PROJ_BRANCH=%s\nPROJ_COMMIT=%s\n' "${PROJ_BRANCH}" "$(git -C PROJ rev-parse HEAD)" >> /usr/local/share/postgis-build-env/build-commits.env && \
     cd PROJ && \
     mkdir cmake-build && \
     #./autogen.sh && ./configure && make -j"$(build-threads)" && make install && \
@@ -155,8 +167,6 @@ RUN git clone --depth 1 --branch ${PROJ_BRANCH} https://github.com/OSGeo/PROJ &&
     #projsync --system-directory --source-id ch_swisstopo && \
     cd /src && rm -rf PROJ/.git PROJ/cmake-build
 
-
-ARG BUILD_DATE
 ENV PGDATA=/var/lib/postgresql
 
 RUN useradd postgres -p paYAHIZz4VZyc -G sudo && \
@@ -167,6 +177,7 @@ ENV PATH="/usr/local/pgsql/bin:${PATH}"
 
 ARG GDAL_BRANCH=master
 RUN git clone --depth 1 --branch ${GDAL_BRANCH} https://github.com/OSGeo/gdal && \
+    printf 'GDAL_BRANCH=%s\nGDAL_COMMIT=%s\n' "${GDAL_BRANCH}" "$(git -C gdal rev-parse HEAD)" >> /usr/local/share/postgis-build-env/build-commits.env && \
     cd gdal && \
     # gdal project directory structure - has been changed !
     if [ -d "gdal" ] ; then \
@@ -185,6 +196,7 @@ RUN git clone --depth 1 --branch ${GDAL_BRANCH} https://github.com/OSGeo/gdal &&
           -DCMAKE_BUILD_TYPE=RelWithDebInfo \
           -DCMAKE_C_FLAGS_RELWITHDEBINFO="${DEBUG_CFLAGS}" \
           -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="${DEBUG_CXXFLAGS}" \
+          ${GDAL_CMAKE_DRIVER_OPTIONS} \
           .. \
         ; \
     fi && \
@@ -193,6 +205,7 @@ RUN git clone --depth 1 --branch ${GDAL_BRANCH} https://github.com/OSGeo/gdal &&
 
 ARG GEOS_BRANCH=master
 RUN git clone --depth 1 --branch ${GEOS_BRANCH} https://github.com/libgeos/geos && \
+    printf 'GEOS_BRANCH=%s\nGEOS_COMMIT=%s\n' "${GEOS_BRANCH}" "$(git -C geos rev-parse HEAD)" >> /usr/local/share/postgis-build-env/build-commits.env && \
     cd geos && \
     mkdir cmake-build && \
     cd cmake-build && \
@@ -207,10 +220,17 @@ RUN git clone --depth 1 --branch ${GEOS_BRANCH} https://github.com/libgeos/geos 
 ARG POSTGRES_BRANCH=master
 ARG PG_CC=gcc
 RUN git clone --depth 1 --branch ${POSTGRES_BRANCH} https://github.com/postgres/postgres && \
+    printf 'POSTGRES_BRANCH=%s\nPOSTGRES_COMMIT=%s\nPOSTGRES_EXTRA_CONFIGURE=%s\n' "${POSTGRES_BRANCH}" "$(git -C postgres rev-parse HEAD)" "${POSTGRES_EXTRA_CONFIGURE}" >> /usr/local/share/postgis-build-env/build-commits.env && \
     cd postgres && \
-    ./configure --enable-cassert --enable-debug CC=${PG_CC} CFLAGS="-ggdb -Og -g3 -fno-omit-frame-pointer" && \
+    ./configure --enable-cassert --enable-debug ${POSTGRES_EXTRA_CONFIGURE} CC=${PG_CC} CFLAGS="-ggdb -Og -g3 -fno-omit-frame-pointer" && \
     make -j"$(build-threads)" && make install && \
     cd /src && rm -rf postgres/.git
+
+RUN printf '%s\n' \
+    '#!/bin/sh' \
+    'cat /usr/local/share/postgis-build-env/build-commits.env' \
+    > /usr/local/bin/postgis-build-env-commits && \
+    chmod 0755 /usr/local/bin/postgis-build-env-commits
 
 # disable requiring password to sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/README.md
+++ b/README.md
@@ -16,3 +16,16 @@ python3 build.py weekly
 Build progress is here - https://debbie.postgis.net/job/PostGIS-build-env/
 
 [![Build Status](https://debbie.postgis.net/buildStatus/icon?job=PostGIS-build-env%2Flabel%3Ddocker)](https://debbie.postgis.net/job/PostGIS-build-env/label=docker/)
+
+Each image records the source branch and commit used for PostgreSQL, GEOS,
+GDAL, PROJ, and SFCGAL in:
+
+```
+/usr/local/share/postgis-build-env/build-commits.env
+```
+
+To print that metadata from a running container:
+
+```
+postgis-build-env-commits
+```

--- a/build.py
+++ b/build.py
@@ -173,7 +173,23 @@ def build_metadata(env):
     else:
         tag = 'pg{PG}{compiler_tag}-geos{GEOS}-gdal{GDAL}-proj{PROJ}'.format_map(versions)
     env['tag'] = tag
+    env['POSTGRES_EXTRA_CONFIGURE'] = postgres_extra_configure(env['PG'])
     return env
+
+
+def postgres_extra_configure(postgres_branch):
+    if postgres_branch == 'master':
+        return '--with-lz4 --with-zstd'
+    match = re.fullmatch(r'REL_(\d+)_STABLE', postgres_branch)
+    if not match:
+        return ''
+    major = int(match.group(1))
+    options = []
+    if major >= 14:
+        options.append('--with-lz4')
+    if major >= 15:
+        options.append('--with-zstd')
+    return ' '.join(options)
 
 
 def select_environments(env_batch, tag):
@@ -223,6 +239,7 @@ if args.print_matrix:
                 'proj': env['PROJ'],
                 'compiler': env['PG_CC'],
                 'sfcgal': env['SFCGAL'],
+                'postgres_extra_configure': env['POSTGRES_EXTRA_CONFIGURE'],
             }
             for env in unique_by_tag(environments)
         ]
@@ -245,6 +262,7 @@ for env in environments:
         '--build-arg', 'PG_CC={PG_CC}'.format_map(env),
         '--build-arg', 'SFCGAL_BRANCH={SFCGAL}'.format_map(env),
         '--build-arg', 'BUILD_THREADS={}'.format(os.environ.get('BUILD_THREADS', 'auto')),
+        '--build-arg', 'POSTGRES_EXTRA_CONFIGURE={POSTGRES_EXTRA_CONFIGURE}'.format_map(env),
     ]
     for image in images:
         build_command.extend(['-t', image])

--- a/build.py
+++ b/build.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
+import argparse
 import datetime
+import json
 import os
 import re
 import subprocess
-import sys
-env_batch = 'all'
-environments = []
+
 all_environments=[
     # put last modified first to iterate faster
         dict(
@@ -157,30 +157,84 @@ all_environments=[
             PG_CC='gcc'
         )
     ]
-if len(sys.argv) > 1:    
-    env_batch =  sys.argv[1]
 
-if env_batch == 'weekly': 
-    environments = all_environments[0:3]
-else:
-    environments = all_environments
 
-print("Env Batch selected:", env_batch, environments)
-
-for env in environments:
+def build_metadata(env):
+    env = env.copy()
     if env['PG_CC'] == 'clang':
         env['compiler_tag'] = "-clang"
     else:
         env['compiler_tag'] = ''
 
-    versions = { k : ''.join(re.findall('\d+', v) or v) for k, v in env.items() }
+    env.setdefault('SFCGAL', 'master')
+    versions = { k : ''.join(re.findall(r'\d+', v) or v) for k, v in env.items() }
     if env['name'] == 'latest':
         tag = 'latest{compiler_tag}'.format_map(versions)
     else:
         tag = 'pg{PG}{compiler_tag}-geos{GEOS}-gdal{GDAL}-proj{PROJ}'.format_map(versions)
-    image = 'postgis/postgis-build-env:{}'.format(tag)
+    env['tag'] = tag
+    return env
 
-    subprocess.check_call([
+
+def select_environments(env_batch, tag):
+    environments = all_environments[0:3] if env_batch == 'weekly' else all_environments
+    environments = [build_metadata(env) for env in environments]
+    if tag:
+        environments = [env for env in environments if env['tag'] == tag]
+        if not environments:
+            raise SystemExit("No environment generates tag {}".format(tag))
+    return environments
+
+
+def unique_by_tag(environments):
+    seen = set()
+    unique = []
+    for env in environments:
+        if env['tag'] in seen:
+            continue
+        seen.add(env['tag'])
+        unique.append(env)
+    return unique
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('batch', nargs='?', default='all', choices=['all', 'weekly'])
+parser.add_argument('--repository', action='append', default=[],
+                    help='Repository to tag and publish, for example postgis/postgis-build-env')
+parser.add_argument('--tag', help='Build only the environment that generates this tag')
+parser.add_argument('--print-matrix', action='store_true',
+                    help='Print a GitHub Actions matrix and exit')
+parser.add_argument('--push', dest='push', action='store_true', default=True)
+parser.add_argument('--no-push', dest='push', action='store_false')
+args = parser.parse_args()
+
+repositories = args.repository or ['postgis/postgis-build-env']
+environments = select_environments(args.batch, args.tag)
+
+if args.print_matrix:
+    print(json.dumps({
+        'include': [
+            {
+                'name': env['name'],
+                'tag': env['tag'],
+                'pg': env['PG'],
+                'geos': env['GEOS'],
+                'gdal': env['GDAL'],
+                'proj': env['PROJ'],
+                'compiler': env['PG_CC'],
+                'sfcgal': env['SFCGAL'],
+            }
+            for env in unique_by_tag(environments)
+        ]
+    }))
+    raise SystemExit(0)
+
+print("Env Batch selected:", args.batch, environments)
+
+for env in environments:
+    images = ['{}:{}'.format(repository, env['tag']) for repository in repositories]
+
+    build_command = [
         'docker', 'build',
         '--pull',
         '--build-arg', 'BUILD_DATE={}'.format(datetime.date.today().strftime("%Y%m%d")),
@@ -191,10 +245,11 @@ for env in environments:
         '--build-arg', 'PG_CC={PG_CC}'.format_map(env),
         '--build-arg', 'SFCGAL_BRANCH={SFCGAL}'.format_map(env),
         '--build-arg', 'BUILD_THREADS={}'.format(os.environ.get('BUILD_THREADS', 'auto')),
-        '-t', image,
-        '.'
-    ])
-    subprocess.check_call([
-        'docker', 'push', image
-    ])
-        
+    ]
+    for image in images:
+        build_command.extend(['-t', image])
+    build_command.append('.')
+    subprocess.check_call(build_command)
+    if args.push:
+        for image in images:
+            subprocess.check_call(['docker', 'push', image])


### PR DESCRIPTION
## Summary

Adds GitHub Actions CI for the PostGIS build environment images and folds in the currently open image-maintenance issues.

The workflow generates its image matrix from `build.py`, builds generated tags on pull requests, and publishes only from `master`. The image build now also:

- builds PostgreSQL 14+ with lz4 support and PostgreSQL 15+/master with zstd support;
- records source branches and commits for PostgreSQL, GEOS, GDAL, PROJ, and SFCGAL inside each image;
- reduces modern CMake GDAL builds by disabling optional drivers and enabling the raster/vector drivers PostGIS CI normally needs.

## What changes

- Adds `.github/workflows/images.yml` with a matrix job and a per-image build job.
- Keeps `build.py` as the single source of truth for the supported build environments.
- Adds `build.py --print-matrix` so GitHub Actions can derive the matrix instead of duplicating the environment list in YAML.
- Adds `build.py --no-push`, `--push`, `--tag`, and repeatable `--repository` options for CI use.
- Builds one selected environment per matrix job and tags that image for every requested repository.
- Adds `liblz4-dev` and `libzstd-dev`, then passes version-gated PostgreSQL configure options from the matrix.
- Writes build provenance to `/usr/local/share/postgis-build-env/build-commits.env` and exposes it through `postgis-build-env-commits`.
- Passes GDAL's CMake minimal-driver switches for current CMake-based GDAL builds while leaving legacy autoconf builds on the existing path.

## Publishing behavior

Pull requests build images with `--no-push`.

Pushes to `master` build the same matrix with `--push` and publish to:

- `postgis/postgis-build-env`, preserving the existing Docker Hub image name.
- `repo.osgeo.org/postgis/build-env`, adding an OSGeo-hosted mirror so the project is not dependent on Docker Hub as the only registry.

The OSGeo credentials are only for the second publish target. `OSGEO_REGISTRY_USERNAME` and `OSGEO_REGISTRY_PASSWORD` should be a repository secret pair that can push to `repo.osgeo.org/postgis/build-env`. They are not used for pull requests, and they are not needed for Docker Hub publishing.

Docker Hub publishing still uses the existing `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets.

## Issue coverage

Closes postgis/postgis-build-env#6.
Closes postgis/postgis-build-env#7.
Closes postgis/postgis-build-env#21.

## Validation

- `python3 -m py_compile build.py`
- `python3 build.py --no-push --print-matrix | python3 -m json.tool`
- Matrix assertions for PostgreSQL 13, 14, 15, and master configure flags
- `git diff --check`
- `docker buildx build --check .`
