### PR TITLE
Limit SFCGAL build parallelism

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ WORKDIR /src
 RUN echo /usr/lib/x86_64-linux-gnu/libeatmydata.so >> /etc/ld.so.preload
 
 ARG BUILD_THREADS=4
+ARG SFCGAL_BUILD_THREADS=1
 ARG DEBUG_CFLAGS="-O2 -g3 -ggdb -fno-omit-frame-pointer -DNDEBUG"
 ARG DEBUG_CXXFLAGS="-O2 -g3 -ggdb -fno-omit-frame-pointer -DNDEBUG"
 
@@ -96,7 +97,7 @@ RUN git clone --depth 1 --branch ${SFCGAL_BRANCH} https://gitlab.com/sfcgal/SFCG
        -DCGAL_DIR="/src/CGAL" \
        -DCMAKE_PREFIX_PATH=/src/CGAL \
        .. && \
-     make -j${BUILD_THREADS} && \
+     make -j${SFCGAL_BUILD_THREADS} && \
      make install && \
      cd /src && rm -rf SFCGAL/.git SFCGAL/cmake-build
 


### PR DESCRIPTION
The weekly image build started failing at the SFCGAL `master` build step after the July 18 successful run. The public Debbie console shows the build still using `make -j4` for SFCGAL and then dying while compiling `algorithm/minkowskiSum.cpp.o`:

```text
c++: fatal error: Killed signal terminated program cc1plus
make[2]: *** [src/CMakeFiles/SFCGAL.dir/build.make:905: src/CMakeFiles/SFCGAL.dir/algorithm/minkowskiSum.cpp.o] Error 1
```

That points at memory pressure during the template-heavy SFCGAL/CGAL compile, not a CMake or source-level SFCGAL error. SFCGAL `master` itself did not change in the July 18-19 window; the observed `master` head is from July 10.

This keeps the existing global `BUILD_THREADS=4` default for the other dependency builds, but adds `SFCGAL_BUILD_THREADS=1` and uses it only for the SFCGAL build. This is a narrow unblocking fix for the current image outage. The broader memory-aware build-thread proposal remains https://github.com/postgis/postgis-build-env/pull/36, but that pull request is currently conflicting.

Validation so far: `docker build --check` passes on this branch, and a patched Docker build confirms the SFCGAL step is using `make -j1`. The full patched build is still running because serial SFCGAL compilation is slow.

Closes https://github.com/postgis/postgis-build-env/issues/40
