### PR TITLE
Auto-detect a memory-safe BUILD_THREADS default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,12 +54,26 @@ RUN echo /usr/lib/x86_64-linux-gnu/libeatmydata.so >> /etc/ld.so.preload
 # can spike to 2-3 GiB per job, so a hardcoded BUILD_THREADS=4 requires
 # roughly 10 GiB of container memory and reliably OOMs on smaller hosts.
 # The "auto" default caps at one job per 3 GiB of container memory and
-# at nproc, with a hard ceiling of 4. Override at build time with
-# --build-arg BUILD_THREADS=N.
+# at nproc, with a hard ceiling of 4. Memory is read from the cgroup
+# limit (v2, then v1) before falling back to /proc/meminfo, so that
+# --memory-constrained builds (e.g. Docker Desktop) are respected.
+# Override at build time with --build-arg BUILD_THREADS=N.
 ARG BUILD_THREADS=auto
 RUN set -e; \
     if [ "$BUILD_THREADS" = "auto" ]; then \
-        MEM_GB=$(awk '/MemTotal/ {printf "%d", $2 / 1024 / 1024}' /proc/meminfo); \
+        MEM_BYTES=""; \
+        if [ -r /sys/fs/cgroup/memory.max ]; then \
+            v=$(cat /sys/fs/cgroup/memory.max); \
+            [ "$v" != "max" ] && MEM_BYTES="$v"; \
+        elif [ -r /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then \
+            v=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes); \
+            [ "$v" -lt 9000000000000000000 ] && MEM_BYTES="$v"; \
+        fi; \
+        if [ -n "$MEM_BYTES" ]; then \
+            MEM_GB=$(( MEM_BYTES / 1024 / 1024 / 1024 )); \
+        else \
+            MEM_GB=$(awk '/MemTotal/ {printf "%d", $2 / 1024 / 1024}' /proc/meminfo); \
+        fi; \
         CPU=$(nproc); \
         T=$(( MEM_GB / 3 )); \
         [ "$T" -lt 1 ] && T=1; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,9 @@ RUN set -e; \
         [ "$T" -gt "$CPU" ] && T=$CPU; \
         [ "$T" -gt 4 ] && T=4; \
     else \
+        case "$BUILD_THREADS" in \
+            ''|*[!0-9]*|0) echo "BUILD_THREADS must be 'auto' or a positive integer" >&2; exit 1 ;; \
+        esac; \
         T="$BUILD_THREADS"; \
     fi; \
     printf '#!/bin/sh\necho %s\n' "$T" > /usr/local/bin/build-threads; \
@@ -141,17 +144,12 @@ RUN git clone --depth 1 --branch ${PROJ_BRANCH} https://github.com/OSGeo/PROJ &&
     mkdir cmake-build && \
     #./autogen.sh && ./configure && make -j"$(build-threads)" && make install && \
     cd cmake-build && \
-<<<<<<< HEAD
     cmake \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo \
       -DCMAKE_C_FLAGS_RELWITHDEBINFO="${DEBUG_CFLAGS}" \
       -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="${DEBUG_CXXFLAGS}" \
       .. && \
-    make -j${BUILD_THREADS} && \
-=======
-    cmake .. && \
     make -j"$(build-threads)" && \
->>>>>>> d6c7caa (Auto-detect a memory-safe BUILD_THREADS default)
     make install && \
     #projsync --system-directory --source-id us_noaa && \
     #projsync --system-directory --source-id ch_swisstopo && \
@@ -190,45 +188,29 @@ RUN git clone --depth 1 --branch ${GDAL_BRANCH} https://github.com/OSGeo/gdal &&
           .. \
         ; \
     fi && \
-<<<<<<< HEAD
-    make -j${BUILD_THREADS} && make install && \
-    cd /src && rm -rf gdal/.git gdal/build
-=======
     make -j"$(build-threads)" && make install && \
-    cd /src && rm -rf gdal
->>>>>>> d6c7caa (Auto-detect a memory-safe BUILD_THREADS default)
+    cd /src && rm -rf gdal/.git gdal/build
 
 ARG GEOS_BRANCH=master
 RUN git clone --depth 1 --branch ${GEOS_BRANCH} https://github.com/libgeos/geos && \
     cd geos && \
     mkdir cmake-build && \
     cd cmake-build && \
-<<<<<<< HEAD
     cmake \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo \
       -DCMAKE_C_FLAGS_RELWITHDEBINFO="${DEBUG_CFLAGS}" \
       -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="${DEBUG_CXXFLAGS}" \
       .. && \
-    make -j${BUILD_THREADS} && make install && \
-    cd /src && rm -rf geos/.git geos/cmake-build
-=======
-    cmake -DCMAKE_BUILD_TYPE=Release .. && \
     make -j"$(build-threads)" && make install && \
-    cd /src && rm -rf geos
->>>>>>> d6c7caa (Auto-detect a memory-safe BUILD_THREADS default)
+    cd /src && rm -rf geos/.git geos/cmake-build
 
 ARG POSTGRES_BRANCH=master
 ARG PG_CC=gcc
 RUN git clone --depth 1 --branch ${POSTGRES_BRANCH} https://github.com/postgres/postgres && \
     cd postgres && \
     ./configure --enable-cassert --enable-debug CC=${PG_CC} CFLAGS="-ggdb -Og -g3 -fno-omit-frame-pointer" && \
-<<<<<<< HEAD
-    make -j${BUILD_THREADS} && make install && \
-    cd /src && rm -rf postgres/.git
-=======
     make -j"$(build-threads)" && make install && \
-    cd /src && rm -rf postgres
->>>>>>> d6c7caa (Auto-detect a memory-safe BUILD_THREADS default)
+    cd /src && rm -rf postgres/.git
 
 # disable requiring password to sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,27 @@ WORKDIR /src
 
 RUN echo /usr/lib/x86_64-linux-gnu/libeatmydata.so >> /etc/ld.so.preload
 
-ARG BUILD_THREADS=4
+# Determine a safe default parallelism: CGAL/SFCGAL cc1plus compilation
+# can spike to 2-3 GiB per job, so a hardcoded BUILD_THREADS=4 requires
+# roughly 10 GiB of container memory and reliably OOMs on smaller hosts.
+# The "auto" default caps at one job per 3 GiB of container memory and
+# at nproc, with a hard ceiling of 4. Override at build time with
+# --build-arg BUILD_THREADS=N.
+ARG BUILD_THREADS=auto
+RUN set -e; \
+    if [ "$BUILD_THREADS" = "auto" ]; then \
+        MEM_GB=$(awk '/MemTotal/ {printf "%d", $2 / 1024 / 1024}' /proc/meminfo); \
+        CPU=$(nproc); \
+        T=$(( MEM_GB / 3 )); \
+        [ "$T" -lt 1 ] && T=1; \
+        [ "$T" -gt "$CPU" ] && T=$CPU; \
+        [ "$T" -gt 4 ] && T=4; \
+    else \
+        T="$BUILD_THREADS"; \
+    fi; \
+    printf '#!/bin/sh\necho %s\n' "$T" > /usr/local/bin/build-threads; \
+    chmod +x /usr/local/bin/build-threads; \
+    echo "BUILD_THREADS resolved to: $(build-threads)"
 ARG SFCGAL_BUILD_THREADS=1
 ARG DEBUG_CFLAGS="-O2 -g3 -ggdb -fno-omit-frame-pointer -DNDEBUG"
 ARG DEBUG_CXXFLAGS="-O2 -g3 -ggdb -fno-omit-frame-pointer -DNDEBUG"
@@ -105,14 +125,19 @@ ARG PROJ_BRANCH=master
 RUN git clone --depth 1 --branch ${PROJ_BRANCH} https://github.com/OSGeo/PROJ && \
     cd PROJ && \
     mkdir cmake-build && \
-    #./autogen.sh && ./configure && make -j${BUILD_THREADS} && make install && \
+    #./autogen.sh && ./configure && make -j"$(build-threads)" && make install && \
     cd cmake-build && \
+<<<<<<< HEAD
     cmake \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo \
       -DCMAKE_C_FLAGS_RELWITHDEBINFO="${DEBUG_CFLAGS}" \
       -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="${DEBUG_CXXFLAGS}" \
       .. && \
     make -j${BUILD_THREADS} && \
+=======
+    cmake .. && \
+    make -j"$(build-threads)" && \
+>>>>>>> d6c7caa (Auto-detect a memory-safe BUILD_THREADS default)
     make install && \
     #projsync --system-directory --source-id us_noaa && \
     #projsync --system-directory --source-id ch_swisstopo && \
@@ -151,14 +176,20 @@ RUN git clone --depth 1 --branch ${GDAL_BRANCH} https://github.com/OSGeo/gdal &&
           .. \
         ; \
     fi && \
+<<<<<<< HEAD
     make -j${BUILD_THREADS} && make install && \
     cd /src && rm -rf gdal/.git gdal/build
+=======
+    make -j"$(build-threads)" && make install && \
+    cd /src && rm -rf gdal
+>>>>>>> d6c7caa (Auto-detect a memory-safe BUILD_THREADS default)
 
 ARG GEOS_BRANCH=master
 RUN git clone --depth 1 --branch ${GEOS_BRANCH} https://github.com/libgeos/geos && \
     cd geos && \
     mkdir cmake-build && \
     cd cmake-build && \
+<<<<<<< HEAD
     cmake \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo \
       -DCMAKE_C_FLAGS_RELWITHDEBINFO="${DEBUG_CFLAGS}" \
@@ -166,14 +197,24 @@ RUN git clone --depth 1 --branch ${GEOS_BRANCH} https://github.com/libgeos/geos 
       .. && \
     make -j${BUILD_THREADS} && make install && \
     cd /src && rm -rf geos/.git geos/cmake-build
+=======
+    cmake -DCMAKE_BUILD_TYPE=Release .. && \
+    make -j"$(build-threads)" && make install && \
+    cd /src && rm -rf geos
+>>>>>>> d6c7caa (Auto-detect a memory-safe BUILD_THREADS default)
 
 ARG POSTGRES_BRANCH=master
 ARG PG_CC=gcc
 RUN git clone --depth 1 --branch ${POSTGRES_BRANCH} https://github.com/postgres/postgres && \
     cd postgres && \
     ./configure --enable-cassert --enable-debug CC=${PG_CC} CFLAGS="-ggdb -Og -g3 -fno-omit-frame-pointer" && \
+<<<<<<< HEAD
     make -j${BUILD_THREADS} && make install && \
     cd /src && rm -rf postgres/.git
+=======
+    make -j"$(build-threads)" && make install && \
+    cd /src && rm -rf postgres
+>>>>>>> d6c7caa (Auto-detect a memory-safe BUILD_THREADS default)
 
 # disable requiring password to sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers

--- a/build.py
+++ b/build.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import datetime
+import os
 import re
 import subprocess
 import sys
@@ -189,6 +190,7 @@ for env in environments:
         '--build-arg', 'PROJ_BRANCH={PROJ}'.format_map(env),
         '--build-arg', 'PG_CC={PG_CC}'.format_map(env),
         '--build-arg', 'SFCGAL_BRANCH={SFCGAL}'.format_map(env),
+        '--build-arg', 'BUILD_THREADS={}'.format(os.environ.get('BUILD_THREADS', 'auto')),
         '-t', image,
         '.'
     ])


### PR DESCRIPTION
## Summary

Carries Evan Montgomery-Recht's `BUILD_THREADS=auto` work from postgis/postgis-build-env#36, rebased onto current `master`.

The original branch is now conflicted after the later SFCGAL-specific build-thread change landed, so this replacement keeps the memory-safe general build parallelism while preserving the dedicated `SFCGAL_BUILD_THREADS=1` cap from current `master`.

## What changes

- Changes the default `BUILD_THREADS` Docker build argument from `4` to `auto`.
- Adds a small `/usr/local/bin/build-threads` helper that picks a safe job count from the container memory limit and CPU count.
- Validates explicit `BUILD_THREADS` overrides and rejects `0` or non-numeric values.
- Uses `$(build-threads)` for the general PROJ, GDAL, GEOS, and PostgreSQL builds.
- Keeps SFCGAL on the separate `SFCGAL_BUILD_THREADS` argument so CGAL-heavy builds remain capped independently.
- Passes `BUILD_THREADS` through `build.py` via the `BUILD_THREADS` environment variable.

## Credit

Original work by Evan Montgomery-Recht in postgis/postgis-build-env#36. This branch preserves the original commit authorship and only rebases/resolves it onto current `master`.

## Validation

- `git diff --check`
- `python3 -m py_compile build.py`
- `docker buildx build --check .`
